### PR TITLE
Update nextflow.config

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -9,7 +9,7 @@ params {
 
     // Machine options
     cluster_options_general = ""
-    gpu_allocated = "--gpus-per-node=V100:1"
+    gpu_allocated = "--gpus-per-node=A100:1"
     DORADO_device = "cuda:0"
 
     // Output


### PR DESCRIPTION
The current nextflow.config GPU specification for UTP does not work on Vera anymore: --gpus-per-node=V100:1, changed to --gpus-per-node=A100:1